### PR TITLE
Dropdown menu for diagram rename/delete

### DIFF
--- a/static/flow/controller-viewer.js
+++ b/static/flow/controller-viewer.js
@@ -4,47 +4,85 @@ var g_diagramSpecs = [];  // a collection of all diagrams on the controller
 
 // prepare an interface for viewing the diagrams contained within a controller
 function initControllerViewer() {
-	
+
 	// if we've already initialized the view but are returning to it again, we should request the list of diagrams again
 	if (g_controllerViewerInitialized) {
 		sendMessage('list_diagrams');
 		return;
 	}
-	
+
 	// subscribe to message for this controller
 	subscribeToFolder(g_controller.path);
-	
+
 	// set outgoing messages to go to this controller
 	setTargetFolder(g_controller.path);
-	
+
 	// open websocket connect to server
 	connectWebSocket(function() {
 		sendMessage('list_diagrams');
 	});
-	
+
 	// handle diagram list message from controller
 	addMessageHandler('diagram_list', function(timestamp, params) {
 		var diagramListDiv = $('#diagramList');
 		diagramListDiv.empty();
 		g_diagramSpecs = params.diagrams;
+
+		var createMenu = function(btnGroup, diagramIndex){
+			var diagramActions = $('<button>', {class: 'btn btn-lg dropdown-toggle', html: '<span class="caret"></span>'});
+			diagramActions
+				.css({ height: '45px'})
+				.attr({ 'data-toggle': 'dropdown'})
+				.appendTo(btnGroup);
+
+			var diagramMenu = $('<ul>', { class: 'dropdown-menu '});
+
+			var renameAction = $('<li>', { html: '<a href="#">Rename</a>' }).appendTo(diagramMenu);
+			var deleteAction = $('<li>', { html: '<a href="#">Delete</a>' }).appendTo(diagramMenu);
+
+			renameAction.click(diagramIndex, function(e){
+				var diagramSpec = g_diagramSpecs[e.data];
+				// TODO: add validator similar to diagram save prompt
+				modalPrompt({title: 'Rename Diagram', prompt: 'Name', default: diagramSpec.name, resultFunc: function(name) {
+					sendMessage('save_diagram', {'name': name, 'diagram': diagramSpec});
+					diagramSpec.name = name;
+					updateDiagramSpec(diagramSpec);
+				}});
+			});
+
+			deleteAction.click(diagramIndex, function(e){
+				var diagramSpec = g_diagramSpecs[e.data];
+				// TODO: add validator similar to diagram save prompt
+				modalConfirm({title: 'Delete Diagram', prompt: 'Are you sure you want to delete this diagram?', yesFunc: function() {
+					sendMessage('delete_diagram', {'name': diagramSpec.name });
+					deleteDiagramSpec(diagramSpec.name);
+				}});
+			});
+			diagramMenu.appendTo(btnGroup);
+		};
+
+
 		for (var i = 0; i < g_diagramSpecs.length; i++) {
 			var diagram = g_diagramSpecs[i];
-			var div = $('<div>');
-			var button = $('<button>', {class: 'btn btn-lg listButton', html: diagram.name}).appendTo(div);
-			button.click(i, function(e) {
+			var diagramDiv = $('<div>', {class: 'listButton'});
+			var btnGroup = $('<div>', {class: 'btn-group'});
+			var diagramName = $('<button>', {class: 'btn btn-lg', html: diagram.name}).appendTo(btnGroup);
+			diagramName.click(i, function(e) {
 				showDiagramEditor();
 				sendMessage('start_diagram', g_diagramSpecs[e.data]);
 				loadDiagram(g_diagramSpecs[e.data]);
 			});
-			div.appendTo(diagramListDiv);
+			createMenu(btnGroup, i)
+			btnGroup.appendTo(diagramDiv);
+			diagramDiv.appendTo(diagramListDiv);
 		}
 	});
-	
+
 	// handle status message from the controller
 	addMessageHandler('status', function(timestamp, params) {
 		console.log(params);
 	})
-	
+
 	g_controllerViewerInitialized = true;
 }
 
@@ -54,6 +92,14 @@ function updateDiagramSpec(diagramSpec) {
 	for (var i = 0; i < g_diagramSpecs.length; i++) {
 		if (g_diagramSpecs[i].name === diagramSpec.name) {
 			g_diagramSpecs[i] = diagramSpec;
+		}
+	}
+}
+
+function deleteDiagramSpec(name) {
+	for (var i = 0; i < g_diagramSpecs.length; i++) {
+		if (g_diagramSpecs[i].name === name) {
+			delete g_diagramSpecs[i];
 		}
 	}
 }

--- a/static/flow/controller-viewer.js
+++ b/static/flow/controller-viewer.js
@@ -43,10 +43,11 @@ function initControllerViewer() {
 			renameAction.click(diagramIndex, function(e){
 				var diagramSpec = g_diagramSpecs[e.data];
 				// TODO: add validator similar to diagram save prompt
-				modalPrompt({title: 'Rename Diagram', prompt: 'Name', default: diagramSpec.name, resultFunc: function(name) {
-					sendMessage('save_diagram', {'name': name, 'diagram': diagramSpec});
-					diagramSpec.name = name;
+				modalPrompt({title: 'Rename Diagram', prompt: 'Name', default: diagramSpec.name, resultFunc: function(newName) {
+					sendMessage('rename_diagram', {'old_name': diagramSpec.name, 'new_name': newName});
+					diagramSpec.name = newName;
 					updateDiagramSpec(diagramSpec);
+					btnGroup.find('.diagram-name').html(newName);
 				}});
 			});
 
@@ -56,6 +57,7 @@ function initControllerViewer() {
 				modalConfirm({title: 'Delete Diagram', prompt: 'Are you sure you want to delete this diagram?', yesFunc: function() {
 					sendMessage('delete_diagram', {'name': diagramSpec.name });
 					deleteDiagramSpec(diagramSpec.name);
+					btnGroup.remove();
 				}});
 			});
 			diagramMenu.appendTo(btnGroup);
@@ -66,7 +68,7 @@ function initControllerViewer() {
 			var diagram = g_diagramSpecs[i];
 			var diagramDiv = $('<div>', {class: 'listButton'});
 			var btnGroup = $('<div>', {class: 'btn-group'});
-			var diagramName = $('<button>', {class: 'btn btn-lg', html: diagram.name}).appendTo(btnGroup);
+			var diagramName = $('<button>', {class: 'btn btn-lg diagram-name', html: diagram.name}).appendTo(btnGroup);
 			diagramName.click(i, function(e) {
 				showDiagramEditor();
 				sendMessage('start_diagram', g_diagramSpecs[e.data]);


### PR DESCRIPTION
Using bootstrap's btn-dropdown functionality for the menu:

http://getbootstrap.com/components/#btn-dropdowns

Added a new method to update the diagramSpecs (to delete a spec) but I think ultimately might want to consider having a listener be the only one to modify the client representation of diagrams to avoid state nastiness. Instead of removing a diagram on the client side, then, instead you'd want to signal deletion to the controller, the controller deletes it and then sends a `list_diagrams` with the new list, which has omitted the deleted diagram