### PR TITLE
Draggable plot blocks

### DIFF
--- a/static/flow/diagram-editor.js
+++ b/static/flow/diagram-editor.js
@@ -203,6 +203,9 @@ function displayBlock(block) {
 		input.keyup(block.id, numberEntryChanged);
 	} else if (block.type === 'plot') {
 		var canvas = $('<canvas>', {class: 'flowBlockPlot', width: 300, height: 200, id: 'bc_' + block.id}).appendTo(blockDiv);
+			canvas.mousedown(blockMouseDown);
+			canvas.mousemove(mouseMove);
+			canvas.mouseup(mouseUp);
 		blockDiv.addClass('flowBlockWithPlot');
 	} else if (block.type === 'camera') {
 		$('<img>', {class: 'flowBlockImage', width: 320, height: 240, id: 'bi_' + block.id}).appendTo(blockDiv);


### PR DESCRIPTION
For some reason, the canvas element of the plot block does not propagate events to the diagram editor element. So, when creating this element, bind the mouse events manually. There might be a more elegant solution possible so I'm reading up a little on event propagation for canvas elements