### PR TITLE
Added .editorconfig and logging to CODAP

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# more info at : http://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# set options for all file types
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/static/flow/codap-bridge.js
+++ b/static/flow/codap-bridge.js
@@ -59,7 +59,32 @@ var CodapTest = {
 			]
 		});
 	},
-	
+
+    // send a log message to CODAP, values should be a dictionary: {topic: <string>, formatStr: <string>, replaceArgs: <array>}
+    // where topic is optional and formatStr can contain %@ placeholders that are replaced with the values in replaceArgs.
+    // example: {formatStr: "Launched rocket with %@ engine toward %@", replaceArgs: ["red", "satellite"]}
+    log: function (values) {
+        // ignore logging if not running in CODAP
+		if(codapInterface.connectionState !== 'active') {
+			return;
+		}
+
+        codapInterface.sendRequest({
+            action: 'notify',
+            resource: 'logMessage',
+            values: values
+        });
+    },
+
+    // shortcut for log() that sets formatStr based on topic
+    logTopic: function (topic) {
+        this.log({
+            topic: topic,
+            formatStr: "Logging topic: %@",
+            replaceArgs: [topic]
+        });
+    },
+
 	// send data to the CODAP; data should be a list of dictionaries: [{field_a: 1, field_b: 2}, {field_a: 3, field_b: 4}]
 	sendData: function(data) {
 		console.log('sending', data.length, 'points to CODAP');

--- a/static/flow/controller-selector.js
+++ b/static/flow/controller-selector.js
@@ -2,7 +2,7 @@
 function initControllerSelector() {
 	var controllerListDiv = $('#controllerList');
 	controllerListDiv.empty();
-	
+
 	// if we have a list of controllers, the user is logged in and can pick one of them
 	if (g_controllers.length) {
 		$('#controllerSelectorLabel').html('Select your controller:');
@@ -12,11 +12,12 @@ function initControllerSelector() {
 			var button = $('<button>', {class: 'btn btn-lg listButton', html: controller.name}).appendTo(div);
 			button.click(i, function(e) {
 				g_controller = g_controllers[e.data];
+                CodapTest.logTopic('Dataflow/SelectPi');
 				showControllerViewer();
 			});
 			div.appendTo(controllerListDiv);
 		}
-	
+
 	// if not, assume user isn't logged in and allow them to type in a controller name
 	} else {
 		$('#controllerSelectorLabel').html('Enter the name of your controller:');
@@ -28,6 +29,7 @@ function initControllerSelector() {
 				data: {controller_name: $('#controller_name_entry').val()},
 				success: function(data) {
 					g_controller = JSON.parse(data);
+                    CodapTest.logTopic('Dataflow/SelectPi');
 					showControllerViewer();
 				},
 				error: function(data) {

--- a/static/flow/controller-viewer.js
+++ b/static/flow/controller-viewer.js
@@ -153,4 +153,5 @@ function newDiagram() {
 	showDiagramEditor();
 	loadDiagram({'blocks': []});  // load an empty diagram
 	sendMessage('set_diagram', {diagram: diagramToSpec(g_diagram)});  // send empty diagram to controller
+    CodapTest.logTopic('Dataflow/CreateDiagram');
 }

--- a/static/flow/diagram-editor.js
+++ b/static/flow/diagram-editor.js
@@ -72,6 +72,7 @@ function pinMouseUp(e) {
 		g_activeStartPin = null;
 		g_activeLineSvg.remove();
 		g_activeLineSvg = null;
+        CodapTest.logTopic('Dataflow/ConnectBlock');
 	}
 }
 
@@ -169,6 +170,7 @@ function viewRecordedData(e) {
 	if (block) {
 		showPlotter();
 		g_viewingBlockId = block.id;
+        CodapTest.logTopic('Dataflow/ViewRecordedData');
 	}
 }
 
@@ -520,6 +522,7 @@ function initDiagramEditor() {
 			g_diagram.blocks.push(block);
 			displayBlock(block);
 			structureModified();
+            CodapTest.logTopic('Dataflow/ConnectSensor');
 		}
 	}
 
@@ -543,7 +546,7 @@ function initDiagramEditor() {
 		$('#startRecording').hide();
 		$('#stopRecording').show();
 	}
-	
+
 	// request list of devices currently connected to controller
 	// fix(soon): if we're loading a diagram, should we do this after we've loaded it?
 	sendMessage('list_devices');
@@ -690,7 +693,7 @@ function showFilterBlockSelector() {
 		"not", "and", "or", "xor", "nand",
 		"plus", "minus", "times", "divided by", "absolute value",
 		"equals", "not equals", "less than", "greater than",
-		"blur", "brightness", "simple moving average", "exponential moving average" 
+		"blur", "brightness", "simple moving average", "exponential moving average"
 	];
 	for (var i = 0; i < filterTypes.length; i++) {
 		var type = filterTypes[i];
@@ -710,6 +713,7 @@ function addPlotBlock() {
 	block.view.y = 300;
 	displayBlock(block);
 	structureModified();
+    CodapTest.logTopic('Dataflow/AddPlot');
 }
 
 
@@ -798,9 +802,11 @@ function startRecordingData() {
 			$('#startRecording').hide();
 			$('#stopRecording').show();
 			$('#recordingSettings').modal('hide');
+            CodapTest.logTopic('Dataflow/SetUpdateRate');
 		}
 	});
 	$('#recordingSettings').modal('show');
+    CodapTest.logTopic('Dataflow/StartRecordingData');
 }
 
 
@@ -810,6 +816,7 @@ function stopRecordingData() {
 	$('#stopRecording').hide();
 	$('#startRecording').show();
 	g_recordingInterval = 0;
+    CodapTest.logTopic('Dataflow/StopRecordingData');
 }
 
 

--- a/static/flow/plotter.js
+++ b/static/flow/plotter.js
@@ -31,7 +31,7 @@ function initPlotter() {
 		});
 		*/
 	}
-	
+
 	// update which blocks are shown in plot
 	var dataPairs = [];
 	for (var i = 0; i < g_diagram.blocks.length; i++) {
@@ -178,7 +178,7 @@ function addBlockToPlotter(block) {
 
 
 function setTimeFrame(timeStr) {
-	
+
 	// compute time bounds
 	var frameSeconds = 0;
 	if (timeStr === '1m'){
@@ -229,32 +229,33 @@ function selectInterval() {
 		$('#selectInterval').html('Select Interval');
 		$('#selectInterval').removeClass('btn-info');
 	} else {
-		g_plotHandler.setIntervalSelect(true);		
+		g_plotHandler.setIntervalSelect(true);
 		$('#selectInterval').html('Done with Interval Selection');
 		$('#selectInterval').addClass('btn-info');
+        CodapTest.logTopic('Dataflow/StartSelectDataToExport');
 	}
 }
 
 
 function exploreRecordedDataInCODAP() {
 	var timeThresh = 0.4;  // seconds
-	var dataPairs = g_plotHandler.plotter.dataPairs;	
+	var dataPairs = g_plotHandler.plotter.dataPairs;
 	if (dataPairs.length && dataPairs[0].xData.data.length) {
-		
+
 		// set collection attributes based on current input blocks
 		var attrs = [{name: 'seconds', type: 'numeric', precision: 2}];
 		for (var i = 0; i < g_diagram.blocks.length; i++) {
 			var block = g_diagram.blocks[i];
 			if (block.inputCount === 0) {
 				attrs.push({
-					name: block.name, 
-					type: 'numeric', 
+					name: block.name,
+					type: 'numeric',
 					precision: 2,
 				});
 			}
 		}
-		CodapTest.prepCollection(attrs);		
-		
+		CodapTest.prepCollection(attrs);
+
 		// get data for quick reference
 		var xs = [];
 		var ys = [];
@@ -262,7 +263,7 @@ function exploreRecordedDataInCODAP() {
 			xs.push(dataPairs[j].xData.data);
 			ys.push(dataPairs[j].yData.data);
 		}
-		
+
 		// get timestamp bounds
 		var frame = g_plotHandler.plotter.frames[0];
 		var minTimestamp = frame.intervalLowerX;
@@ -275,13 +276,13 @@ function exploreRecordedDataInCODAP() {
 				ind[j] = -1;  // no data; done with this pair
 			}
 		}
-		
+
 		// merge the sequences
 		var data = [];
 		var startTimestamp = null;
 		var step = 0;
 		while (1) {
-			
+
 			// get current timestamp: min across sequences at current position
 			var timestamp = null;
 			for (var j = 0; j < dataPairs.length; j++) {
@@ -292,15 +293,15 @@ function exploreRecordedDataInCODAP() {
 					}
 				}
 			}
-			
+
 			// if no timestamp, then we've reached the end of all sequences, stop here
 			if (timestamp === null) {
 				break;
 			}
-						
+
 			// check whether to keep this point
 			var keepPoint = ((minTimestamp === null || timestamp >= minTimestamp - timeThresh) && (maxTimestamp === null || timestamp <= maxTimestamp + timeThresh));
-				
+
 			// first timestamp will be start timestamp
 			if (keepPoint && startTimestamp === null) {
 				startTimestamp = timestamp;
@@ -322,22 +323,23 @@ function exploreRecordedDataInCODAP() {
 					}
 				}
 			}
-			
+
 			// add to data set to send to CODAP
 			if (keepPoint) {
 				dataPoint['seconds'] = timestamp - startTimestamp;
 				data.push(dataPoint);
 			}
-			
+
 			// sanity check
 			step++;
 			if (step > 3000) {
 				break;
 			}
 		}
-		
+
 		// send data to CODAP
 		CodapTest.sendData(data);
+        CodapTest.logTopic('Dataflow/ExportDataToCODAP');
 	}
 }
 

--- a/templates/flow-app.html
+++ b/templates/flow-app.html
@@ -23,6 +23,12 @@
 	<script src="/ext/flow-server/static/external/iframe-phone.js"></script>
 	<script src="/ext/flow-server/static/external/CodapInterface.js"></script>
 	<script src="/ext/flow-server/static/flow/codap-bridge.js"></script>
+{% else %}
+    <script>
+        window.CodapTest = {
+            logTopic: function () {}
+        };
+    </script>
 {% endif %}
 
 	<link rel="stylesheet" href="/ext/flow-server/static/flow/style.css">


### PR DESCRIPTION
The .editorconfig file ensures that tab/space conventions are automatically set in any editors that support it (see http://editorconfig.org/)

For logging:

- two new functions were added to CodapTest: log() and logTopic()
- logTopic() calls were inserted to support triggers for external Getting Started data interactive