### PR TITLE
Added missing Dataflow/ViewRecordedData logTopic call

### DIFF
--- a/static/flow/diagram-editor.js
+++ b/static/flow/diagram-editor.js
@@ -243,6 +243,7 @@ function viewRecordedData(e) {
         }
     } else {
             showPlotter();
+            CodapTest.logTopic('Dataflow/ViewRecordedData');
     }
 }
 


### PR DESCRIPTION
This was causing the "Getting Started" data interactive to block.