### PR TITLE
handle null resource content

### DIFF
--- a/ext.py
+++ b/ext.py
@@ -252,7 +252,10 @@ def file_operation(operation, type):
     #
     def _load():
         resource    = find_resource(path)
-        data        = read_resource(resource).decode('utf-8')
+        data        = read_resource(resource)
+        if data is not None:
+            data = data.decode('utf-8')
+        
         return json.dumps({
                     'success': True,
                     'message': 'Loaded file %s.' % (resource.name),


### PR DESCRIPTION
Some existing resources have no content, so they were giving this error:

`AttributeError: 'NoneType' object has no attribute 'decode'`